### PR TITLE
Expand grammar compendium to lessons 1-50

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
--- Schémas & types
+--- Schémas & types
+
+> 📚 Consultez également la synthèse des [leçons 1 à 50](docs/lecons-1-50.md) pour les points de grammaire et de vocabulaire.
 create schema if not exists app;
 
 create type app.quiz_type as enum ('MCQ','LISTEN','MATCH','TYPE','SPEAK_PLACEHOLDER');

--- a/docs/lecons-1-50.md
+++ b/docs/lecons-1-50.md
@@ -1,0 +1,399 @@
+# Leçons 1 à 50
+
+Ce document rassemble les notions abordées dans les cinquante premières leçons de grammaire créole martiniquaise. Les exemples
+restent en créole avec leur traduction française lorsque cela éclaire l'usage.
+
+## Leçons 1 à 32 — Bases de morphologie et de syntaxe
+
+### Leçon 1 — L’article défini postposé
+
+- **Forme générale** : l’article défini suit le nom et varie selon la finale.
+  - Après consonne → `la` : `boug-la` (« le type »), `fanm-lan` (« la femme »).
+  - Après voyelle → `a` : `loto-a` (« la voiture »), `lajan-a` (« l’argent »).
+  - Après syllabe nasale → `lan` ou `an` : `flanm-lan` (« la flamme »), `sitwon-an` (« le citron »).
+- **Variantes** : ajout d’une consonne de liaison (`dlo-a`, `zépon-an`, `zyé-a`, `jaden-an`) ou nasalisation (`wan`, `yan`).
+- **Relatives** : si l’antécédent porte l’article défini, un article de rappel clôt la relative : `boug-la man wè a` (« le type que j’ai vu »).
+- **Valeurs pragmatiques** : l’article rapproche dans l’espace, le temps ou la relation (`Pòl-la man té palé zòt la`).
+- **Trait d’union indispensable** pour distinguer `fanm kouyon-an` (« la femme de l’idiot ») de `fanm kouyon an` (« la femme idiote »).
+- **Formes lexicalisées** : `jòdi-a`, `aprézan-an`, `talè-a`, `isi-a`, `oswè-a`, `lapli-a`.
+- **Absence de genre grammatical** : seul le genre sémantique (mâle / femelle / inanimé) est distingué.
+
+### Leçon 2 — L’article indéfini
+
+- **Forme unique `an`** placée avant le nom : `an boug` (« un type »), `an madanm` (« une femme »).
+- **Absence de genre** et emploi dans les récits (`té ni an fwa...`).
+- **Pluriel indéfini** : déterminant zéro (`man wè kay`), ou forme `dé` dans certains contextes (`mi dé boug kouyon !`).
+- **Exclamatives** : `yan` (« un de ces… ! »), `an sèl`, `yann tou sèl` (pronoms).
+- **Négation** : `man pa wè an zanmi`, `man pa wè pyès zanmi` (aucun).
+- **Liaisons prosodiques** : éviter la liaison française (`an istilo`).
+- **Polyvalence de `an`** : article, préposition (`an 2`), article défini (`an 3`).
+
+### Leçon 3 — Le pluriel
+
+- **Défini** : `sé ...-la` (nom finissant par consonne) / `sé ...-a` (finissant par voyelle).
+- **Indéfini** : déterminant zéro (`man ni soulyé`) ou `dé` selon le contexte (`sé dé kouyon`).
+- **Valeur générique** : `i enmen fanm` (« il aime les femmes ») vs `i enmen sé fanm-la` (« ces femmes-là »).
+- **Variantes dialectales** : `lé boug-la` (Sainte-Marie).
+- **Possessifs** : `tamwen` (général), `sé tamwen-an` (particulier).
+- **Ambiguïtés prosodiques** : `moun la` (« les gens de là-bas ») vs `moun-la` (« la personne »).
+
+### Leçon 4 — Pronoms personnels
+
+- **Sujets** : `mwen / man`, `wou / ou / 'w`, `li / i / y`, `nou`, `zòt`, `yo`.
+- **Compléments** : même série, placée après le verbe (`i pa wè mwen`, `man bat ou`).
+- **Pronoms toniques** : `misyé`, `manzèl`, `sé mésyé`/`sé manzèl` pour insister.
+- **Pronoms après préposition** : forme soudée après voyelle (`pou'y`, `ba'y`).
+- **Ordre des doubles compléments** : indirect (personne) avant direct (objet) → `man ka ba'y li`.
+- **Pronom neutre `sa`** pour l’objet inanimé (`nou fè sa`).
+- **Réfléchis soudés** : `kòmwen`, `kòw`, `kòy`, etc.
+- **Intensifs** : `mwen menm`, `li menm`, etc.
+
+### Leçon 5 — Possessifs
+
+- **Construction nominale** : nom + pronom (`tab li`), article nécessaire pour valeur spécifique (`tab-li a`).
+- **Article absent pour relations uniques** : `papa'w`, `madanm ou` (sauf emphase ou pluralité).
+- **Pronoms possessifs** : `ta` + pronom → `tamwen`, `ta'w`, `ta'y`, `tanou`, `tazòt`, `tayo`; formes définies `ta'w la`, `sé ta'y la`.
+- **Questions / exclamations** : `kisa ki ta'w ?`, `tout sé vyé ta'w la`.
+
+### Leçon 6 — Démonstratifs
+
+- **Adjectif/pronom `tala`** postposé (`bagay-tala`, `boug-tala`). Variante courte `taa`.
+- **Pronominalisation** : `tala ki palé a`, `sé tala` (pluriel).
+- **Article défini à valeur démonstrative** : `boug-la`, `oswè-a`, `isi-a`.
+- **Pronom `sa`** pour « cela » et `sé` comme présentatif (`sé sa man lé`).
+
+### Leçon 7 — Pronoms relatifs
+
+- **Sujet** : `ki` ; **complément** : forme zéro.
+- **Article de rappel obligatoire** si l’antécédent est défini (`kabrit-la ou maré a`).
+- **Particule explétive `éti`** optionnelle (`boug-la éti ki...`).
+- **Traductions** : `dont` → structure avec `di'y`, `an`, `'y la`; `où` → préposition + pronom (`péyi-a oti man ka alé adan'y la`).
+- **Forme `sa ki`** : valeur neutre générique (`man pa sav sa ki rivé'y`).
+
+### Leçon 8 — L’interrogation
+
+- **Intonation** suffisant (`ou ka vini, an ?`).
+- **Particules** : `an`, `wi`, `non`, `pa vré ?`.
+- **Introductions** : `ès` / `ési` (interrogation directe ou indirecte).
+- **Interrogatifs** :
+  - `ki moun`, `kilès` ;
+  - `(ki) sa`, `ki bagay` ;
+  - `ki`, `kilès` pour « quel/lequel » ;
+  - `koté`, `oti`, `ola`, `éti` pour « où » ;
+  - `ki mannyè`, `kouman` ;
+  - `poutji`, `poukisa` ;
+  - `ki tan`, `ki jou`.
+- **Relatif obligatoire** après l’interrogatif (`ki moun ki...`).
+
+### Leçon 9 — La négation
+
+- **Particule `pa`** devant le verbe (`i pa ni lajan`).
+- **Futur/conditionnel** : `pa` → `pé` (`man pé ké vini`).
+- **Impératif négatif** : `pa` + verbe (`pa pléré`).
+- **Verbe `pé`** : attention à la place (`i pa pé` vs `i pé pa`).
+- **Notions spécifiques** :
+  - `pòkò / poko` (« pas encore »),
+  - `pa ... ankò` (« ne ... plus »),
+  - `pyès` (« pas du tout », `pyès moun` → personne, `ayen` → rien),
+  - `janmen / jen` (« jamais »),
+  - `anni` pour limiter ou menacer (`anni ou pa vini...`).
+- **Combinaisons** : `pa té dwèt`, `i dwèt pa`, `i pé pa pa vini`.
+- **Expressions** : `pa menm palé !`, `penga...` pour la mise en garde.
+
+### Leçon 10 — L’exclamation
+
+- **Intensif `fout`** et variantes (`fwenk`, `fonk`).
+- **Autres interjections** : `wi`, `mé`, `wo`, `dann`, `aten/laten`, `papa/manman`, `mésyé`, `mézanmi`, `an an an an`, `woy/woy`, `mi`, `joy`, `yan`, `pou`.
+- **Combinaisons** : `mi loto, mi !`, `joy kalté vyé bradjak !`.
+
+### Leçon 11 — La préposition « à »
+
+- **Forme zéro** pour attribution (`ba Pyè lajan`), caractérisation (`an fanm gro tété`), localisation (`man ka alé lanmès`), certains verbes (`i ba mwen chwezi`).
+- **Formes pleines** selon le contexte : `a` (temps, caractérisation), `ta` (possession), `an` (localisation), `épi` (comparaison), `ala` (manière), `ka` (durée/insistance), `ba` (attribution), `pou` (but), `o` (lieu), `rivé` (destination).
+
+### Leçon 12 — La préposition « de »
+
+- **Forme zéro** pour appartenance (`joujou timanmay-la`), partitif (`i bwè dlo`), pluriel indéfini, nombreux verbes, provenance (`boug Fòdfrans la`), complément d’adjectif, manière, dénombrement.
+- **Formes pleines** :
+  - `di` après certains verbes ou prépositions (`i ka otjipé di yich li`, `an plis di sa`).
+  - `sòti` pour l’origine (`sòti Senpyè`).
+  - `an` pour la matière ou la manière (`an tab an bwa`).
+  - `adan` pour le dénombrement ou la localisation (`dé adan yo`).
+
+### Leçon 13 — Autres prépositions (I)
+
+- **`pou`** : but (`pou ou pé sa viv`), intérêt (`i ka travay pou yich li`), identification (`ou ka pran mwen pou an makak`), destination (`i pati pou Frans`), appréciation (`pou kouyon, i kouyon`).
+- **`ba`** : bénéfice (`i ka travay ba bétjé-a`), faveur (`man ké fè tou sa man pé ba'w`).
+- **Orientation** : `koté`, `o/oti`, `pabò/pakoté` pour « vers » ; `nou ka alé o Pòl`.
+- **Localisation interne** : `an`, `adan`, `ann`, `andidan`.
+- **`chez`** : `kay`, `lakay`, `akay`, `éti`.
+- **`contre`** : `kont` (opposition), `épi` (avec pour lutter), `bò` (proximité immédiate).
+
+### Leçon 14 — Autres prépositions (II)
+
+- **`épi`** (« avec ») : moyen (`yo pa ka pran mouch épi vinèg`), accompagnement, appartenance à un camp (`sa ki pa épi mwen`), caractérisation, considération, opposition, verbes (`palé épi...`).
+- **`ansanm épi`** : « avec » (ensemble).
+- **Inventaire rapide** : `apré`, `avan`, `dépi`, `dèyè`, `douvan`, `ant`, `épi` (envers), `adan`/`an mitan` (parmi), `déwò`, `jik`, `magré`, `an plis di`, `san`, `silon`, `anba`, `anlè/asou`.
+
+### Leçon 15 — Le verbe « être »
+
+- **Forme zéro** devant adjectif, lieu, temps, profession (`Pyè kontan`, `i doktè`).
+- **Copule `sé`** devant un nom (`Féfé sé an tigason`). Négation : `ou pa an nonm`.
+- **Forme déplacée `yé`** pour questions, focalisations (`koté i yé ?`, `sé dòktè i yé`).
+- **Forme pleine `èt`** pour lever les ambiguïtés (`i lé èt fò`).
+
+### Leçon 16 — Aspect du présent
+
+- **Particule `ka`** marque le déroulement ou l’habitude (`man ka chanté`, `i toujou ka travay`).
+- **Peut se combiner avec `té`, `ké`** pour passé/futur duratifs.
+- **Verbes sans `ka`** (état, modalité) : `enmen`, `konnèt`, `pè`, `swef`, `fen`, `ni`, `sav/sa`, `lé`, `pé`, `anvi`, `bouzwen`, `dwèt` (sauf pour l’habitude).
+- **Impersonnel** : `koumansé ka fè cho`, `ka fè nwè`.
+
+### Leçon 17 — Les temps du passé
+
+- **Forme zéro** : accompli du présent / passé simple (`yo pati`, `man wè'y`).
+- **Particule `té` seule** : plus-que-parfait pour verbes compatibles avec `ka`, passé global pour verbes statifs (`man té lé`).
+- **`té ka`** : imparfait (`i té ka travay`).
+- **Présentatif passé** : `sé té...`, `sé pa té...`.
+
+### Leçon 18 — Futur et conditionnel
+
+- **Particule `ké`** : futur simple (`nou ké dòmi`). Variante imminente `kay/kèy/kéy`.
+- **`ka` + `ké`** : futur progressif (`nou ké ka dòmi`).
+- **Négation** : `pé ké`.
+- **Antériorité** : `lé man ké fini manjé` (futur antérieur).
+- **Conditionnel** : `té ké` (+ éventuellement `ka`). Variante optative `sé` ; proche dans le temps `té kay`.
+
+### Leçon 19 — La phrase conditionnelle
+
+- **Conjonctions** : `si`, `siyanka`.
+- **Combinaisons courantes** :
+  - `si` + présent → futur ou présent (`si ou rivé..., nou ka ba...`).
+  - `si` + `té ka`/`té` → `té ké` (`si ou té ka travay..., ou té ké ni...`).
+  - Optatif `sé` possible (`si ou sé alé..., man sé vini`).
+  - `siyanka` + présent → futur ; `siyanka` + `té ké` → conditionnel ; `siyanka` + optatif pour hypothèses fortes.
+
+### Leçon 20 — Mode impératif, exhortation et souhait
+
+- **Forme simple** pour l’ordre ou la défense (`sòti la !`, `pa menyen mwen !`).
+- **Renforcement** avec pronom (`sòti'w !`).
+- **Redoublement** pour insistance (`manjé manjé'w !`).
+- **Verbes sans impératif propre** (`lé`, `pé`, etc.) → utiliser périphrases (`anni lé...`).
+- **Particules modales** : `anni`, `kon`, `tout tan`, `tou sa`.
+- **Formes avec `kité`, `ba/prété`, `annou` (1re pers.), particules `en`, `i`, `hon`.
+- **Souhaits** : `ki mwen pa tann zòt ankò !`.
+
+### Leçon 21 — La voix passive
+
+- **Absence de flexion** : même ordre qu’à l’actif, sujet mis en avant (`lajan-tala prété pou dé lanné`).
+- **Participe lexicalisé** : `pri` (de `pran`), `fèt` (de `fè`), `bay` (de `ba`).
+- **Autres participes** possibles (`kalbòsé`, `tonbé`).
+- **Propositions participiales** après verbes de perception (`man ka wè'y ka monté mòn-la`).
+
+### Leçon 22 — Verbes composés
+
+- **Combinaisons directionnelles** : `vini/alé`, `mennen alé` (emmener), `pòté vini` (apporter), `alé vini` (aller-retour).
+- **Effet aspectuel** : redoublements (`tonbé lévé`, `monté désann`).
+- **Autres combinaisons** : `gadé wè`, `chèché gadé wè` (insistance).
+- **Régime** porté par le verbe lexical principal (`pòté sa viré`).
+
+### Leçon 23 — Obligation et probabilité
+
+- **`fok/fo`** : obligation impersonnelle ou personnelle (`fok ou travay`).
+- **`pou` + présentatif `sé` ou sans** : devoir moral (`sé pati pou pati`).
+- **`dwèt`** : devoir et probabilité (`Pyè dwèt travay`, `sé bòg-la dwèt chape`). Variantes temporelles (`ou té dwèt pati`).
+
+### Leçon 24 — Pouvoir (`pé`)
+
+- **Capacité et possibilité** (`ou pé pati`, `sa pé fèt`).
+- **Avec `sa`** pour la réussite (`pou i pé sa manjé`).
+- **Renforcement impératif** : `travay kon zòt pé...`.
+- **Négation** : `pé ké`, `pété ké`.
+- **Possibilité modale** : `i pé ja rivé`, `i pé pa té sòti`.
+- **Expression atténuée** : `i sé pé` (« il aurait dû »).
+
+### Leçon 25 — La particule `sé`
+
+- **Présentatif** (`sé sa man lé`).
+- **Marque du pluriel défini** (`sé zanmi'w la`).
+- **Copule** (`ou sé an salop`).
+- **Optatif / conditionnel** (`man sé bwè an koko`).
+- **Combinaisons** possibles de plusieurs `sé` dans une phrase.
+
+### Leçon 26 — Le nom commun
+
+- **Blocage de l’article** pour valeur générique (`loto pa pou vini la`).
+- **Nominalisation d’adjectifs/adverbes** (`débouya pa péché`).
+- **Préfixes lexicalisés** : `lajistis`, `lenjistis`, `lakraponni`, etc.
+- **Verbes employés comme noms** (`fè an kay`, `dòmi dous`).
+- **Particules intensives** : `an ti konyen`, `an gwo dòmi`.
+
+### Leçon 27 — Noms propres, titres, termes d’adresse
+
+- **Article + nom propre** pour distanciation (`Misyé Pòl la`).
+- **Formules d’adresse** : `misyé li jij`, `misyé labé`, `sé mésyé-a`, `sé madanm-lan`, `sé manzèl-la`.
+- **Vocatifs** : `mâché`, `monchè`, `léfrè`, `lékouz`, `lézonm`.
+- **Famille** : `ami Roro`, `mèt Félis`, `pè Nèstò`, `sè Éliza`, `tant Jili`, `tonton Riko`.
+- **Noms de pays** : prépositions adaptées (`yo o Zétazini`, `yo ka soti an Frans`).
+
+### Leçon 28 — L’adjectif
+
+- **Primaires intensifs/diminutifs** : `bèl bèl`, `gwo`, `ti`, `vidjò`, `obidjoul`.
+- **Dérivés** avec suffixes (`dyèzè/dyèzèz`, `wontè/wontèz`).
+- **Position** : certains avant le nom (`bidim`, `ti monyonyon`), d’autres après (`blé`, `pyétè`).
+- **Syntagmes adjectivaux** : `vanmennen`, `an chyen`, `anbafèy`.
+- **Remarques** : `fanm kouyon an` vs `fanm kouyon-an`; `man kontan` peut signifier « aimer ».
+
+### Leçon 29 — Le comparatif
+
+- **Supériorité** : `pli ... ki`, `plis ... ki`, `pasé` (`Féfé dyézè pasé Pyè`).
+- **Égalité** : `osi ... ki`, `otan ... otan`.
+- **Infériorité** : `mwen/mwens ... ki`.
+- **Intensificateurs** : `titak`, `anlo`, `anpil`, `lontan`.
+- **Ambiguïtés** : `man enmen Éliza pasé'w` vs `man enmen Éliza plis ki'w`.
+
+### Leçon 30 — Le superlatif
+
+- **Relatif** : `pli` / `mwen` + article défini (`mwen gwo kabrit-la`). Distinction `sé ...-a` vs `lé ...`.
+- **Subjonctif français** déclenché par superlatif indéfini (`sé boug pli séryé man konnèt`).
+- **Absolu** : redoublement (`bèl bèl`), particules (`menm`), adverbes (`anpil`, `toubannman`, `tou`).
+
+### Leçon 31 — Quantification (1)
+
+- **`tout`** : totalité, générique ou spécifique (`tout moun`, `tout sé moun-la`).
+- **Autres quantifieurs** : `chak`, `tjèk`, `yonndé`, `dotwa`, `an bon enpé`, `an bon tibren`, `anpatjé`.
+- **`menm`** pour identité (`yo ka vann menm loto`).
+- **`kalté`** pour classifier (`nou pa enmen kalté moun-tala`).
+
+### Leçon 32 — Quantification (2)
+
+- **Cardinaux** : `yann`, `dé`, `twa`, ... `san`, `mil`; emplois spécifiques (`ni dé lanné nou la`).
+- **Intensifs à partir des cardinaux** : `sé pa dé mò`, `sé pa kat dòmi`.
+- **Distinction analytique / synthétique** : `dé lanné-a` vs `sé dé lanné-a`.
+- **Ordinaux** : `prèmyé`, `dézyèm`, etc., avec ou sans article (`an dézyèm fi`, `sé dé dènyé fwa-tala`).
+- **Autres quantifieurs** : `lo`, `tèlman`, `an étsétéra`, `an boul`, antiphrase `titak`/`tibren`.
+
+## Leçons 33 à 50 — Structures complexes et enrichissements
+
+### Leçon 33 — Tournures impersonnelles et équivalents de « on »
+
+#### 1. Tournures impersonnelles
+
+- **Absence de sujet réel** : `koumansé ka fè cho` (« il commence à faire chaud »), `koumansé té ka fè solèy` (« il commençait à y avoir du soleil »).
+- **Verbes _mantjé_ et _rété_** : `mantjé Pòl dé zoranj` (« il manque à Paul deux oranges »), `i mantjé dé zoranj`, `pa rété mwen pa yann`.
+- **Autres tournures** : `sé bèl pou bèl`, `sé pati pou pati avan i two ta`, `sé (pou) pran douvan avan i two ta`.
+- **Expressions figées** : `i midi`, `ni` / `té ni`, `isi-a pa djè bèl`, `la pa djè lwen`, `(sé) zafè kò'w !`, `(sé) zavè tjou'w !`, `défann fimen`.
+
+#### 2. Équivalents du pronom indéfini « on »
+
+- **Deuxième personne `ou`** : `lè ou dwé an moun...`, `ou pa té ké jen di i las`, `pli ou ka travay, se pli ou ké ni lajan`, etc.
+- **Troisième personne `yo`** : `yo sé di`, `yo balyé lakou-a`, `yo ja prété moun kay-la`, `yo fè anlo bwi anlè sa`.
+
+### Leçon 34 — Équivalents de « en » et « y »
+
+#### 1. Le pronom adverbial « en »
+
+- Peut être rendu par un pronom (`i plen kay li épi yo`, `man sav ki non'y`) ou rester implicite (`man ké ba'w`, `i pran an bèl`).
+- Expressions : `ba mwen dé`, `man fouté'y`, `Pyè rann li`, `nou trapé`, `man pa wè pyès`, `i pòté zoranj, mé nou pa achté` (`nou pa achté yo`).
+- Tours figés : `kouyon kon pa ni`, `man bouf`, `man élijé`, `pa menm palé !`, `man anvi`.
+
+#### 2. Le pronom adverbial « y »
+
+- Généralement non traduit (`ès ou ka alé lékòl ? Wi, man ka alé`).
+- Possibles traductions : `nou ka alé adan'y`, `zòt pa adan`, `wi, man ja alé la`.
+- Avec `ni` : `ni ki pa lé pati`, `ni yann ki pa lé pati`, `ni bèl, jenn, vyé`.
+
+### Leçon 35 — « Devenir », « sembler », « ressembler », « se mettre à »
+
+- Verbes utilisés : `rivé`, `vini`, `tounen`, `viré`, `monté`, `désann`, `ridésann`, `glisé`, `fè`, `lévé`, `tonbé`, `ritounen`, `déviré`, `pasé`, `antré`, `mété kò`.
+- Exemples : `i rivé doktè`, `i ka lévé anrajé`, `i vini flègèdè`, `i vini pa ka palé ankò`, `i tonbé gad kaka`.
+- Constructions avec `tounen`, `viré`, `ritounen` pour redevenir ; rappels sur `y` avec `ni`.
+
+### Leçon 36 — « Tout » et concession
+
+- `i pran tout kannik`, `tout sé kannik-la`, `i pran yo tout`.
+- Conjonction `tout tan` (« tant que »), `tou sa` (« tout ce qui »).
+- Valeur concessive : `tout dòmi i ka dòmi a, i toujou las`, `tout mò Féfé mò a...`, `tout chayé i chayé moun-la...`.
+- Variantes : `tout prêté i prêté mwen lajan-an`, `tout prélè Pyè prélè a`, `tout wonm i bwè wonm-la`.
+
+### Leçon 37 — Notes
+
+- Emploi de `sa ki` / `tou sa ki` (« ce qu'il faut »).
+
+### Leçon 38 — Le mot « menm »
+
+- **Adjectif/pronom** : `an menm chimen`, `sé menm moun-la`, `mwen menm`, etc.
+- **Valeur emphatique** : `Pyè lé li menm alé Fodfrans`, `menm bèt, menm pwèl`.
+- **Concession** : `kanmenm i sé ba mwen lajan...`, `kanmenm ou présé...`, `kanmenm i sé vini...`.
+
+### Leçons 39 à 41 — Réduplication
+
+- Processus pour accentuer : duplication d’adjectifs (`bon`, `gwo`, `ti`, `vyé`, `bèl`, `sèl`), d’adverbes (`anlo`, `lo`, `titak`), de numéraux (`dé`, `twa`, `kat`), ou de groupes (`an bèl jé`, `bon kalté`, `an bon tibren`).
+- Exemples par mot :
+  - **`bon`** : `Pyè ka dòmi bon dòmi`, `i mò bon mò`, `i ka chanté bon chanté`.
+  - **`gwo`** : `i ka dòmi gwo dòmi`, `Pyè tounen kouyon gwo kouyon`.
+  - **`ti`** (antiphrase) : `sé pa ti fè yo fè kont mwen`, `sé pa ti lajan Pyè ba Pòl`.
+  - **`vyé`** : `man éséyé dòmi an vyé ti dòmi`.
+  - **`bèl`** : `Pyè dòmi an bèl dòmi`, `i chayé an bèl dlo`, `Pyè fouté Pòl tjok an bèl fouté`.
+  - **`sèl`** : `Pyè dòmi an sèl dòmi`, `sé pa an sèl mandé i ja mandé mwen`.
+  - **Groupes** : `Pyè dòmi an bèl jé dòmi`, `Pyè ka dòmi bon kalté dòmi a`, `Pyè ka chanté bon kalté chanté a`.
+  - **Adverbes** : `i ka chanté anlo chanté`, `Pyè ka dòmi tibren dòmi` (antiphrase), `lo dòmi i ka dòmi`.
+  - **Quantifieurs** : `sé pa tèlman dòmi i dòmi`, `sé pa dé alé i alé lékòl`, `i dòmi an bon tibren dòmi`, `tout dòmi i ka dòmi a`.
+
+### Leçon 42 — Subordonnées temporelles
+
+- Conjonctions : `konsa` (aussitôt que), `avan`, `apré`, `pandan/toupandan/toukon`, `dépi`, `dépi jou-a / dépi lè-a`, `touttan`, `jistan/jisatan/jiktan`, `chaklè`, `konsa/owa/owala`, `lè`.
+- `ou wè` peut s’ajouter pour l’insistance.
+- Exemple de réduplication : `rivé Pyè rivé, nou pati`.
+
+### Leçon 43 — Subordonnées de cause
+
+- Conjonctions : `pas`, `pis/piski`, `zafè`, `davrè`, `diwè`, `kon/toukon`, `pou lapéti`.
+- Valeurs : cause directe (`pas nou té ka véyé bèf`), justification (`pis ou ja la`), fait constaté (`zafè Pyè pa ka travay la`), raison factuelle (`davrè man pa té sav`), considérations (`pou lapéti man konnèt papa'w`).
+
+### Leçon 44 — Subordonnées de concession et de but / conséquence
+
+- Concession : `magré`, `kanmenm`, `menm`, `tou/tout` (`tou palé i ka palé fò a`).
+- But : `pou` + verbe (`i fè sa pou (i) pé sa trapé boul-la`).
+- Conséquence : `tèlman`, `sitèlman`, `tansifèt` (`Pyè tèlman kouyon...`, `Pyè sitèlman wo...`).
+
+### Leçon 45 — Coordination
+
+- Conjonctions : `épi`, `ouben/oben/o`, `mé/poutan`, `donk/kidonk`, `é`, `ni`, variantes francisées (`néyanmwen`, `kaw`, `Òw`).
+- `épi` peut supprimer le pronom répété (`Pyè ka bwè épi manjé`).
+- Distinction coordination / composition (`bwè manjé` → nourri à l’œil).
+
+### Leçon 46 — Subordonnées relatives (rappel)
+
+- Article de rappel en fin de relative (`boug-la ki ka rété Fòdfrans la`).
+- Obligation du relatif après interrogatif (`ki moun ki pati ?`).
+- Relatif sujet `ki`, complément zéro ; assimilation phonétique possible (`sé mèt-la k'ka palé`).
+- Possibilité d’appositions (`Féfé, ki ka rété Fòdfrans la...`).
+- Compléments : datif (`boug-la man ba'y lajan-an`), locatif (`jou-a man vini wè'w la`), comparatif (`boug-la ou ka kouri vit pasé'y la`).
+- Particule `éti` facultative (`lanné-a éti ki pasé a`).
+
+### Leçon 47 — Subordonnées de condition (compléments)
+
+- Outre `si`, emploi de `dépi` (pourvu que), `an sipozisyon/an sipoyisyon` (à supposer que), `povik` (pourvu que, créole francisé).
+- L’ordre subordonnée + principale, introduite par `sé` et `ki fè`, est fréquent (`sé pas nou pa té ni lajan ki fè nou pa pati`).
+- Formules avec `ou wè` renforcent l’énoncé (`lè ou wè Pyè pati...`).
+
+### Leçon 48 — Dislocation et mise en relief
+
+- Dislocation à gauche / droite (`Pyè, i mété tab-la...`, `tab-la, Pyè mété'y...`, `chanm-lan, Pyè mété tab-la adan'y`).
+- Doublage pronominal (`Pyè, li, i sòti`).
+- Transformations focales : `sé mèt-la ki palé`, `sé mèt-la ki palé a`, `tala ki palé a, sé mèt-la`.
+- Autres procédés : réduplication, morphème `pou`, tournure `sé vini man ka vini`.
+
+### Leçon 49 — Quelques adverbes
+
+- Inventaire thématique : intensité (`asiré pa pitèt`, `toubannman`), temps (`tanto`, `talè`), lieu (`alantou`, `anba`, `anlè`), manière (`franchman`, `dousman`), quantité (`anlo`, `anpatjé`), fréquence (`souvan`), opposition (`okontrè`, `toufwazékant`), etc.
+- Expressions figées et nuances (`an bon tibren`, `kantékant`, `pyanm-pyanm`).
+
+### Leçon 50 — Onomatopées
+
+- Bruits et situations : `bay lè` (avancer), `bip/bokoto`, `blip`, `blogodo`, `boum`, `chèlèlè`, `cho cho cho`, `chou`, `doudoum`, `dya`, `flip/chwa/zim/vlap/blap/bim`, `kokiyoko`, `krik krak`, `kwililik`, `kya/kra`, `mach`, `plim/pim`, `po`, `roy roy roy`, `swit`, `tamtikitikdam`, `tikiting`, `tja tja tja`.
+
+---
+
+**Index alphabétique (extrait)** : rappel des principales entrées (articles, adverbes, particules, verbes, structures) pour faciliter la navigation dans les notions abordées.


### PR DESCRIPTION
## Summary
- rename the lesson compendium to cover all lessons 1 to 50
- add structured notes for lessons 1 to 32 covering articles, pronouns, verbs and syntax
- update the existing sections for lessons 33 to 50 within the unified document and refresh the README link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc81afeb4832e974f62beef250346