### PR TITLE
Add authenticated backend with Stripe subscriptions and protected modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.env
+.env.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+data/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -18,6 +18,42 @@ exercices auto-corrigés,
 
 dialogues et mini-scénarios.
 
+## 🚀 Plateforme web & authentification
+
+Le dépôt inclut désormais un backend Express (Node.js) pour la gestion des comptes et des abonnements Stripe.
+
+### Démarrage
+
+1. Créez un fichier `.env` à la racine avec au minimum :
+
+   ```env
+   JWT_SECRET="change-me"
+   STRIPE_SECRET_KEY="sk_test_..."      # optionnel mais nécessaire pour Stripe
+   STRIPE_WEBHOOK_SECRET="whsec_..."    # optionnel pour activer les webhooks
+   PORT=3000
+   ```
+
+2. Installez les dépendances puis démarrez le serveur :
+
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+3. Les pages publiques sont servies depuis `public/` :
+
+   - `/login.html` : connexion
+   - `/signup.html` : création de compte
+   - `/subscribe.html` : état d’abonnement
+   - `/modules/*` : modules protégés (sessions + abonnement actif requis)
+
+### Fonctionnement
+
+- Inscription / connexion : routes JSON sous `/api/auth/*` (hash bcrypt, cookie HTTPOnly).
+- Stockage : base SQLite (`data/app.sqlite`) initialisée automatiquement.
+- Stripe : route webhook `/webhooks/stripe` qui met à jour le statut d’abonnement (`active` / `inactive`).
+- Protection : garde côté serveur pour les routes `/modules/*` et côté client (`public/js/session.js`).
+
 📦 Structure du dépôt
 .
 ├─ data/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "kreyolang-landing",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "main": "server/app.js",
+  "scripts": {
+    "dev": "nodemon server/app.js",
+    "start": "node server/app.js"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "cookie-parser": "^1.4.6",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "stripe": "^14.24.0",
+    "better-sqlite3": "^9.4.3"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.0"
+  }
+}

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -1,0 +1,107 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: #f6f6f6;
+  color: #1f1f1f;
+  min-height: 100vh;
+}
+
+main {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 2rem;
+}
+
+.module__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: #edf2ff;
+  color: #1a237e;
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+form.auth-form {
+  max-width: 400px;
+  margin: 3rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 2rem;
+  background: white;
+  border-radius: 16px;
+  box-shadow: 0 20px 45px -24px rgba(15, 23, 42, 0.35);
+}
+
+.auth-form h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  text-align: center;
+}
+
+.auth-form label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  color: #1e1b4b;
+}
+
+.auth-form input {
+  margin-top: 0.35rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid #c7d2fe;
+  font-size: 1rem;
+}
+
+.auth-form button {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: none;
+  background: #4338ca;
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.auth-form button:hover,
+.auth-form button:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 15px 35px -18px rgba(67, 56, 202, 0.65);
+}
+
+.auth-form .form-footer {
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.alert {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: #fee2e2;
+  color: #b91c1c;
+  font-weight: 500;
+  text-align: center;
+}
+
+.alert.success {
+  background: #dcfce7;
+  color: #166534;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,806 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Grammaire Martiniquaise</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f5f0ff;
+      --fg: #1a1237;
+      --accent: #8b5cf6;
+      --accent-strong: #6d28d9;
+      --muted: #665f80;
+      --surface: rgba(255, 255, 255, 0.68);
+      --surface-strong: rgba(139, 92, 246, 0.16);
+      --shadow: rgba(45, 24, 87, 0.18);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #090414;
+        --fg: #f5f3ff;
+        --accent: #a78bfa;
+        --accent-strong: #7c3aed;
+        --muted: #b8b0d6;
+        --surface: rgba(30, 17, 52, 0.72);
+        --surface-strong: rgba(124, 58, 237, 0.32);
+        --shadow: rgba(9, 4, 20, 0.45);
+      }
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      min-height: 100vh;
+      background: radial-gradient(circle at top right, rgba(139, 92, 246, 0.25), transparent 45%),
+        radial-gradient(circle at bottom left, rgba(56, 189, 248, 0.18), transparent 50%),
+        linear-gradient(180deg, var(--bg), rgba(245, 240, 255, 0.88));
+      color: var(--fg);
+    }
+
+    header {
+      background: linear-gradient(140deg, rgba(139, 92, 246, 0.95), rgba(56, 189, 248, 0.85));
+      color: white;
+      padding: 3.5rem 1.5rem 2.25rem;
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+
+    header::before {
+      content: "";
+      position: absolute;
+      inset: -120px;
+      background: radial-gradient(circle, rgba(255, 255, 255, 0.35) 0%, transparent 65%);
+      opacity: 0.6;
+      pointer-events: none;
+    }
+
+    header * {
+      position: relative;
+      z-index: 1;
+    }
+
+    header h1 {
+      margin: 0;
+      font-size: clamp(2rem, 5vw, 3rem);
+    }
+
+    header p {
+      margin: 0.75rem auto 0;
+      max-width: 60ch;
+      font-size: 1.1rem;
+    }
+
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      padding: 1rem 1.5rem;
+      backdrop-filter: blur(14px);
+      background: linear-gradient(180deg, rgba(245, 240, 255, 0.82), rgba(245, 240, 255, 0.4));
+      border-bottom: 1px solid var(--surface-strong);
+    }
+
+    .lesson-nav {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .menu-toggle {
+      appearance: none;
+      border: none;
+      background: linear-gradient(135deg, rgba(139, 92, 246, 0.85), rgba(56, 189, 248, 0.75));
+      color: white;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      padding: 0.85rem 1.4rem;
+      border-radius: 999px;
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      box-shadow: 0 18px 35px rgba(80, 56, 160, 0.32);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    .menu-toggle:focus-visible {
+      outline: 2px solid rgba(255, 255, 255, 0.7);
+      outline-offset: 3px;
+    }
+
+    .menu-toggle:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 22px 40px rgba(80, 56, 160, 0.36);
+    }
+
+    .menu-toggle svg {
+      width: 1rem;
+      height: 1rem;
+      transition: transform 0.2s ease;
+    }
+
+    .menu-toggle[aria-expanded="true"] svg {
+      transform: rotate(180deg);
+    }
+
+    .menu-panel {
+      position: absolute;
+      top: calc(100% + 0.75rem);
+      right: 1.5rem;
+      width: min(640px, calc(100% - 3rem));
+      max-height: min(70vh, 540px);
+      overflow-y: auto;
+      background: var(--surface);
+      border-radius: 24px;
+      padding: 1.25rem;
+      box-shadow: 0 28px 60px var(--shadow);
+      border: 1px solid var(--surface-strong);
+      backdrop-filter: blur(22px);
+      display: grid;
+      gap: 1.25rem;
+    }
+
+    .menu-panel::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: linear-gradient(145deg, rgba(139, 92, 246, 0.22), rgba(56, 189, 248, 0.12));
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    .menu-group {
+      position: relative;
+      z-index: 1;
+    }
+
+    .menu-group-title {
+      font-size: 0.75rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin: 0 0 0.75rem;
+    }
+
+    .menu-group ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 0.5rem;
+    }
+
+    .menu-group a {
+      display: block;
+      text-decoration: none;
+      color: var(--fg);
+      font-weight: 600;
+      padding: 0.65rem 0.9rem;
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.25);
+      transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+      backdrop-filter: blur(4px);
+    }
+
+    .menu-group a:hover,
+    .menu-group a:focus {
+      background: rgba(139, 92, 246, 0.25);
+      color: var(--accent-strong);
+      transform: translateX(3px);
+      box-shadow: 0 10px 20px rgba(80, 56, 160, 0.18);
+      outline: none;
+    }
+
+    @media (max-width: 720px) {
+      .lesson-nav {
+        justify-content: center;
+      }
+
+      .menu-panel {
+        right: 50%;
+        transform: translateX(50%);
+      }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      nav {
+        background: linear-gradient(180deg, rgba(12, 6, 26, 0.9), rgba(12, 6, 26, 0.55));
+      }
+
+      footer p {
+        background: rgba(30, 17, 52, 0.62);
+      }
+    }
+
+    main {
+      padding: 3rem 1.5rem 4.5rem;
+      max-width: 1100px;
+      margin: 0 auto;
+      display: grid;
+      gap: clamp(1.8rem, 3vw, 2.8rem);
+    }
+
+    section {
+      background: var(--surface);
+      border-radius: 26px;
+      padding: clamp(1.75rem, 2.4vw, 2.65rem);
+      box-shadow: 0 20px 55px var(--shadow);
+      border: 1px solid var(--surface-strong);
+      backdrop-filter: blur(18px);
+    }
+
+    section h2 {
+      margin-top: 0;
+      color: var(--accent-strong);
+      font-size: clamp(1.65rem, 3vw, 2.1rem);
+      margin-bottom: 0.75rem;
+    }
+
+    h3 {
+      color: var(--muted);
+      margin-bottom: 0.6rem;
+      font-size: 1.05rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    p {
+      margin: 0.6rem 0;
+    }
+
+    ul,
+    ol {
+      margin: 0.75rem 0 0.75rem 1.25rem;
+      padding: 0;
+    }
+
+    li {
+      margin-bottom: 0.45rem;
+    }
+
+    .examples {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 0.75rem;
+      margin: 1rem 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .examples li {
+      background: rgba(139, 92, 246, 0.12);
+      border-left: 4px solid rgba(139, 92, 246, 0.85);
+      padding: 0.9rem 1.1rem;
+      border-radius: 14px;
+      margin: 0;
+      box-shadow: inset 0 0 0 1px rgba(139, 92, 246, 0.08);
+    }
+
+    .note {
+      background: rgba(250, 204, 21, 0.18);
+      border-left: 4px solid #facc15;
+      padding: 0.85rem 1.1rem;
+      border-radius: 14px;
+      margin: 1.2rem 0;
+      color: inherit;
+      box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.12);
+    }
+
+    footer {
+      text-align: center;
+      padding: 2.5rem 1.5rem 3.5rem;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    footer p {
+      margin: 0;
+      display: inline-flex;
+      align-items: center;
+      gap: 0.6rem;
+      padding: 1rem 1.75rem;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.38);
+      border: 1px solid var(--surface-strong);
+      backdrop-filter: blur(16px);
+      box-shadow: 0 12px 30px var(--shadow);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Grammaire Martiniquaise</h1>
+    <p>Une compilation des principales règles grammaticales du créole martiniquais organisée en leçons pour accompagner vos exercices et révisions.</p>
+  </header>
+
+  <nav aria-label="Navigation des leçons">
+    <div class="lesson-nav">
+      <button class="menu-toggle" type="button" aria-expanded="false">
+        Leçons
+        <svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M4.5 7l5.5 6 5.5-6" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </button>
+      <div class="menu-panel" hidden>
+        <div class="menu-group">
+          <p class="menu-group-title">Module 1 · Déterminants et interactions</p>
+          <ul>
+            <li><a href="#lesson-1">L’article défini</a></li>
+            <li><a href="#lesson-2">L’article indéfini</a></li>
+            <li><a href="#lesson-3">Le pluriel</a></li>
+            <li><a href="#lesson-4">Les pronoms personnels</a></li>
+            <li><a href="#lesson-5">Les possessifs</a></li>
+            <li><a href="#lesson-6">Les démonstratifs</a></li>
+            <li><a href="#lesson-7">Les relatifs</a></li>
+            <li><a href="#lesson-8">L’interrogation</a></li>
+            <li><a href="#lesson-9">La négation</a></li>
+          </ul>
+        </div>
+        <div class="menu-group">
+          <p class="menu-group-title">Module 2 · Prépositions et expressions</p>
+          <ul>
+            <li><a href="#lesson-10">L’exclamation</a></li>
+            <li><a href="#lesson-11">La préposition « à »</a></li>
+            <li><a href="#lesson-12">La préposition « de »</a></li>
+            <li><a href="#lesson-13">Autres prépositions (I)</a></li>
+            <li><a href="#lesson-14">Autres prépositions (II)</a></li>
+          </ul>
+        </div>
+        <div class="menu-group">
+          <p class="menu-group-title">Module 3 · Verbe et temps</p>
+          <ul>
+            <li><a href="#lesson-15">Le verbe « être »</a></li>
+            <li><a href="#lesson-16">Présent et particule « ka »</a></li>
+            <li><a href="#lesson-17">Le passé</a></li>
+            <li><a href="#lesson-18">Futur et conditionnel</a></li>
+            <li><a href="#lesson-19">La phrase conditionnelle</a></li>
+            <li><a href="#lesson-20">L’impératif</a></li>
+            <li><a href="#lesson-21">Le passif</a></li>
+            <li><a href="#lesson-22">Les verbes composés</a></li>
+            <li><a href="#lesson-23">Obligation et probabilité</a></li>
+            <li><a href="#lesson-24">Le verbe « pouvoir »</a></li>
+          </ul>
+        </div>
+        <div class="menu-group">
+          <p class="menu-group-title">Module 4 · Structures nominales et quantification</p>
+          <ul>
+            <li><a href="#lesson-25">Les usages de « sé »</a></li>
+            <li><a href="#lesson-26">Le nom commun</a></li>
+            <li><a href="#lesson-27">Noms propres, titres et adresses</a></li>
+            <li><a href="#lesson-28">L’adjectif</a></li>
+            <li><a href="#lesson-29">Le comparatif</a></li>
+            <li><a href="#lesson-30">Le superlatif</a></li>
+            <li><a href="#lesson-31">Quantification et numération (I)</a></li>
+            <li><a href="#lesson-32">Quantification et numération (II)</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section id="lesson-1">
+      <h2>L’article défini</h2>
+      <p>L’article défini du créole martiniquais est postposé et varie selon la finale phonétique du nom. Les formes principales sont <strong>-la</strong> après une consonne et <strong>-a</strong> après une voyelle. Après une voyelle nasale, on rencontre les variantes <strong>-lan</strong> et <strong>-an</strong>; d’autres formes comme <strong>-wa</strong>, <strong>-wan</strong>, <strong>-ya</strong> ou <strong>-yan</strong> peuvent apparaître selon la liaison.</p>
+      <ul class="examples">
+        <li><strong>boug-la</strong> : le type · <strong>fanm-lan</strong> : la femme</li>
+        <li><strong>loto-a</strong> : la voiture · <strong>sitwon-an</strong> : le citron</li>
+        <li><strong>dto-wa</strong> : l’eau · <strong>zyé-ya</strong> : l’œil</li>
+        <li><strong>kabrit la ou maré a</strong> : la chèvre que tu as attachée</li>
+      </ul>
+      <p>Dans les relatives, le « que » français est implicite et un article de rappel se place en fin de subordonnée lorsque l’antécédent possède déjà un article défini. Le trait d’union est indispensable pour distinguer les constructions nominales des adjectifs.</p>
+      <div class="note">Le créole martiniquais ne marque pas le genre grammatical : seules les distinctions sémantiques (mâle, femelle, inanimé) sont conservées.</div>
+    </section>
+
+    <section id="lesson-2">
+      <h2>L’article indéfini</h2>
+      <p>L’indéfini possède la forme unique <strong>an</strong> placée avant le nom, sans distinction de genre. Il peut se combiner avec des possessifs ou d’autres déterminants. Au pluriel, l’absence d’article marque l’indéfini (« forme zéro »), mais on peut rencontrer <strong>dé</strong> dans des contextes spécifiques ou exclamations avec <strong>yan</strong>.</p>
+      <ul class="examples">
+        <li><strong>an boug</strong> : un type · <strong>an madanm</strong> : une femme</li>
+        <li><strong>té ni an fwa…</strong> : il était une fois</li>
+        <li><strong>Mi dé boug kouyon !</strong> : Voilà des types idiots !</li>
+        <li><strong>man pa wè pyès zanmi</strong> : je n’ai vu aucun ami</li>
+      </ul>
+      <p>La négation introduit des nuances : <strong>pa</strong> + indéfini pour « ne… pas », <strong>pyès</strong> pour « aucun ». Des formes pronominales dérivées (par ex. <strong>yann</strong>) expriment « un seul ».</p>
+    </section>
+
+    <section id="lesson-3">
+      <h2>Le pluriel</h2>
+      <p>Le pluriel défini se forme avec <strong>sé …-la</strong> ou <strong>sé …-a</strong> selon la finale du mot, alors que le pluriel indéfini est généralement exprimé par la forme zéro ou par <strong>dé</strong>. L’article permet de distinguer les ensembles particuliers des valeurs générales.</p>
+      <ul class="examples">
+        <li><strong>sé bèf-la</strong> : les bœufs · <strong>sé soulyé-a</strong> : les chaussures</li>
+        <li><strong>man wè kay</strong> : j’ai vu des maisons · <strong>man wè sé kay-la</strong> : j’ai vu les maisons</li>
+        <li><strong>sé mèt-la ka palé</strong> : les maîtres parlent</li>
+        <li><strong>tamwen</strong> : les miens (général) · <strong>sé tamwen-an</strong> : les miens (particulier)</li>
+      </ul>
+      <p>Selon les régions, d’autres marques comme <strong>lé</strong> peuvent remplacer <strong>sé</strong>. Les possessifs se combinent avec l’article pour préciser la portée.</p>
+    </section>
+
+    <section id="lesson-4">
+      <h2>Les pronoms personnels</h2>
+      <p>Les pronoms distinguent formes toniques et atones, avec des variantes après voyelle. Les pronoms objets suivent toujours le verbe. Les compléments directs de chose utilisent souvent <strong>sa</strong> plutôt qu’un pronom personnel.</p>
+      <ul class="examples">
+        <li><strong>mwen / man</strong> : je · <strong>wou / ou / ’w</strong> : tu · <strong>li / i / y</strong> : il/elle</li>
+        <li><strong>man wè’w</strong> : je t’ai vu(e) · <strong>kité’y palé</strong> : laisse-le parler</li>
+        <li><strong>man ka ba’y li</strong> : je le lui donne (personne avant objet)</li>
+        <li><strong>nou fè sa</strong> : nous l’avons fait</li>
+      </ul>
+      <p>Les formes réfléchies fusionnent avec <strong>kò-</strong> (ex. <strong>kòmwen</strong>). Les intensifs (<strong>mwen menm la</strong>) servent à insister sur le sujet.</p>
+    </section>
+
+    <section id="lesson-5">
+      <h2>Les possessifs</h2>
+      <p>La possession se marque en plaçant le pronom personnel après le nom. L’article défini détermine la portée (générale ou particulière). Les formes pronominales dérivées utilisent la particule <strong>ta</strong> pour exprimer « le mien », « les nôtres », etc.</p>
+      <ul class="examples">
+        <li><strong>tab li</strong> : ses tables (général) · <strong>tab li a</strong> : sa table</li>
+        <li><strong>loto mwen</strong> : mes voitures · <strong>loto mwen an</strong> : ma voiture</li>
+        <li><strong>tamwen</strong> : les miens · <strong>tamwen an</strong> : le mien</li>
+        <li><strong>kisa ki ta’w ?</strong> : qu’est-ce qui est à toi ?</li>
+      </ul>
+      <p>Lorsque l’on présume l’unicité (parents, conjoint), l’article disparaît : <strong>papa’w</strong>, <strong>manman’w</strong>. Des tournures comme <strong>an yich mwen</strong> signifient « un de mes enfants ».</p>
+    </section>
+
+    <section id="lesson-6">
+      <h2>Les démonstratifs</h2>
+      <p>Le démonstratif adjectival <strong>tala</strong> se place après le nom avec un trait d’union. Des variantes abrégées (<strong>taa</strong>) existent. Le pluriel se forme avec <strong>sé</strong> et des pronoms démonstratifs (<strong>sé tala</strong>) reprennent l’antécédent.</p>
+      <ul class="examples">
+        <li><strong>bagay-tala</strong> : cette chose-ci/là</li>
+        <li><strong>sé moun-tala</strong> : ces gens-là</li>
+        <li><strong>tala ki palé a sé mèt-la</strong> : celui qui a parlé, c’est le maître</li>
+        <li><strong>ba mwen sa</strong> : donne-moi cela</li>
+      </ul>
+      <p>L’article défini peut jouer un rôle démonstratif (<strong>boug-la</strong> = « ce type »). Les expressions temporelles (<strong>oswè-a</strong>, <strong>bonmaten-an</strong>) utilisent l’article pour indiquer la précision.</p>
+    </section>
+
+    <section id="lesson-7">
+      <h2>Les relatifs</h2>
+      <p>Le relatif <strong>ki</strong> s’utilise lorsque l’antécédent est sujet, tandis que la forme zéro s’applique aux compléments. Un article de rappel clôt les subordonnées lorsque l’antécédent est déterminé. Le mot explétif <strong>éti</strong> peut précéder le relatif.</p>
+      <ul class="examples">
+        <li><strong>sé Pyè ki vòlé bèf-la</strong> : c’est Pierre qui a volé le bœuf</li>
+        <li><strong>sé bèf-la Pyè vòlé</strong> : c’est le bœuf que Pierre a volé</li>
+        <li><strong>boug-la ki ka rété Fodfrans la</strong> : le type qui habite Fort-de-France</li>
+        <li><strong>koutla-a man ka koupé kann épi’y la</strong> : le coutelas avec lequel je coupe la canne</li>
+      </ul>
+      <p>Les traductions de « dont », « où », « lequel » s’appuient sur des structures possessives ou prépositionnelles (<strong>mi boug-la i té ka palé’w la</strong>).</p>
+    </section>
+
+    <section id="lesson-8">
+      <h2>L’interrogation</h2>
+      <p>L’interrogation se marque par l’intonation ou par des particules (<strong>ès</strong>, <strong>an</strong>, <strong>wi</strong>, <strong>non</strong>, <strong>pa vré</strong>). Les interrogatifs se combinent souvent avec le relatif <strong>ki</strong>.</p>
+      <ul class="examples">
+        <li><strong>ou ka vini, an ?</strong> : tu viens ?</li>
+        <li><strong>ès i fè sa ?</strong> : est-ce qu’il a fait ça ?</li>
+        <li><strong>ki moun ki fè sa ?</strong> : qui a fait ça ?</li>
+        <li><strong>poutji ou pa vini ?</strong> : pourquoi n’es-tu pas venu ?</li>
+      </ul>
+      <p>Les formes interrogatives couvrent qui (<strong>ki moun</strong>), quoi (<strong>kisa</strong>), quel (<strong>kilès</strong>), où (<strong>koté</strong>, <strong>oti</strong>), comment (<strong>ki mannyè</strong>), pourquoi (<strong>poutji</strong>), quand (<strong>ki tan</strong>, <strong>ki jou</strong>).</p>
+    </section>
+
+    <section id="lesson-9">
+      <h2>La négation</h2>
+      <p>La particule <strong>pa</strong> précède le verbe pour exprimer la négation. Selon le temps, elle peut varier : <strong>pé</strong> devant <strong>ké</strong> (futur/conditionnel), <strong>poko</strong> pour « pas encore », <strong>pa… ankò</strong> pour « ne… plus ».</p>
+      <ul class="examples">
+        <li><strong>i pa ni lajan</strong> : il n’a pas d’argent</li>
+        <li><strong>nou pé ké kontan</strong> : nous ne serons pas contents</li>
+        <li><strong>i pòkò fè sa</strong> : il ne l’a pas encore fait</li>
+        <li><strong>man pa wè pyès moun</strong> : je n’ai vu personne</li>
+      </ul>
+      <p>Des intensificateurs comme <strong>pyès</strong>, <strong>ayen</strong>, <strong>janmen</strong> renforcent la négation. La place de <strong>pa</strong> autour du verbe <strong>pé</strong> (pouvoir) influe sur le sens (<strong>i pa pé</strong> vs <strong>i pé pa</strong>).</p>
+    </section>
+
+    <section id="lesson-10">
+      <h2>L’exclamation</h2>
+      <p>Plusieurs particules expriment l’exclamation et l’intensité : <strong>fout</strong>, <strong>wi</strong>, <strong>mé</strong>, <strong>wo</strong>, <strong>dann</strong>, <strong>aten</strong>, <strong>papa</strong>, <strong>mézanmi</strong>, <strong>an</strong>, <strong>woy</strong>, <strong>mi</strong>, <strong>joy</strong>, <strong>yan</strong>, <strong>pou</strong>. Elles peuvent être autonomes ou combinées pour renforcer une réaction.</p>
+      <ul class="examples">
+        <li><strong>fout madanm-la bèl !</strong> : que la dame est belle !</li>
+        <li><strong>mé i mové !</strong> : qu’il est méchant !</li>
+        <li><strong>woy woy woy !</strong> : oh là là !</li>
+        <li><strong>mi kalté gwo madanm !</strong> : quelle grosse femme !</li>
+      </ul>
+      <p>Certains termes sont répétés pour intensifier l’émotion (<strong>pa… pa… pa…</strong>, <strong>an an an an</strong>).</p>
+    </section>
+
+    <section id="lesson-11">
+      <h2>La préposition « à »</h2>
+      <p>La préposition française « à » peut être rendue par une forme zéro ou par diverses particules selon le contexte : <strong>a</strong>, <strong>ta</strong>, <strong>an</strong>, <strong>épi</strong>, <strong>ala</strong>, <strong>ka</strong>, <strong>ba</strong>, <strong>pou</strong>, <strong>o</strong>, <strong>rivé</strong>.</p>
+      <ul class="examples">
+        <li><strong>ba Pyè lajan</strong> : donne de l’argent à Pierre</li>
+        <li><strong>man ka alé lanmès</strong> : je vais à la messe</li>
+        <li><strong>vini a katrè</strong> : viens à quatre heures</li>
+        <li><strong>pòté patjé-tala ba papa’w</strong> : porte ce paquet à ton père</li>
+      </ul>
+      <p>Les constructions diffèrent selon qu’il s’agit d’attribution, de caractérisation, de localisation, de destination ou de verbe particulier.</p>
+    </section>
+
+    <section id="lesson-12">
+      <h2>La préposition « de »</h2>
+      <p>« De » se traduit par la forme zéro pour l’appartenance, la partitive, la provenance, etc., mais aussi par <strong>di</strong>, <strong>sòti</strong>, <strong>an</strong>, ou <strong>adan</strong> selon la nuance (matière, provenance, localisation, dénombrement).</p>
+      <ul class="examples">
+        <li><strong>joujou timanmay-la</strong> : le jouet de l’enfant</li>
+        <li><strong>i bwè dlo</strong> : il a bu de l’eau</li>
+        <li><strong>man kontan di’w</strong> : je suis content de toi</li>
+        <li><strong>dè adan yo chapé</strong> : deux d’entre eux se sont échappés</li>
+      </ul>
+    </section>
+
+    <section id="lesson-13">
+      <h2>Autres prépositions (I)</h2>
+      <p>Les prépositions françaises « pour », « vers », « en/dans », « chez », « contre » se rendent en créole par plusieurs équivalents dépendant du sens précis.</p>
+      <ul class="examples">
+        <li><strong>man ka travay pou érisi</strong> : je travaille pour réussir</li>
+        <li><strong>man ké fè tou sa man pé ba’w</strong> : je ferai tout ce que je peux pour toi</li>
+        <li><strong>nou ka alé o Pòl</strong> : nous allons vers Paul</li>
+        <li><strong>pòté sa alé lakay Pyè</strong> : porte ça chez Pierre</li>
+        <li><strong>nou ké goumen kont yo</strong> : nous nous battrons contre eux</li>
+      </ul>
+    </section>
+
+    <section id="lesson-14">
+      <h2>Autres prépositions (II)</h2>
+      <p><strong>épi</strong> traduit fréquemment « avec », complété par <strong>ansanm épi</strong> pour l’accompagnement. D’autres prépositions usuelles : <strong>apré</strong>, <strong>avan</strong>, <strong>dépi</strong>, <strong>dèyè</strong>, <strong>douvan</strong>, <strong>ant</strong>, <strong>adan</strong>, <strong>an déwò</strong>, <strong>jik</strong>, <strong>magré</strong>, <strong>san</strong>, <strong>silon</strong>, <strong>anba</strong>, <strong>anlè</strong>.</p>
+      <ul class="examples">
+        <li><strong>frè mwen vini épi madanm li</strong> : mon frère est venu avec sa femme</li>
+        <li><strong>dèyè kay-la</strong> : derrière la maison</li>
+        <li><strong>ann Italie</strong> : en Italie</li>
+        <li><strong>anba tab-la</strong> : sous la table</li>
+      </ul>
+    </section>
+
+    <section id="lesson-15">
+      <h2>Le verbe « être »</h2>
+      <p>Quatre stratégies rendent « être » : forme zéro devant adjectif ou compléments, copule <strong>sé</strong> devant un nom, forme <strong>yé</strong> pour les constructions disloquées ou interrogatives, et verbe plein <strong>èt</strong> dans certains contextes.</p>
+      <ul class="examples">
+        <li><strong>Pyè kontan</strong> : Pierre est content</li>
+        <li><strong>Féfé sé an tigason</strong> : Féfé est un petit garçon</li>
+        <li><strong>koté i yé ?</strong> : où est-il ?</li>
+        <li><strong>i lé èt an bon doktè</strong> : il veut être un bon médecin</li>
+      </ul>
+    </section>
+
+    <section id="lesson-16">
+      <h2>Présent et particule « ka »</h2>
+      <p>La particule <strong>ka</strong> exprime l’aspect duratif ou habituel. Elle peut disparaître avec certains verbes statifs (<strong>enmen</strong>, <strong>konnèt</strong>, <strong>ni</strong>, <strong>sav</strong>, etc.) sauf pour indiquer l’habitude.</p>
+      <ul class="examples">
+        <li><strong>man ka chanté</strong> : je chante / je suis en train de chanter</li>
+        <li><strong>Pyè ka pran kouri</strong> : Pierre se met à courir</li>
+        <li><strong>i pa ka travay ankò</strong> : il ne travaille plus</li>
+        <li><strong>man sav sa</strong> : je sais ça (sans <strong>ka</strong>)</li>
+      </ul>
+    </section>
+
+    <section id="lesson-17">
+      <h2>Le passé</h2>
+      <p>Le passé s’exprime par la forme simple (équivalent passé composé/passé simple) ou par la particule <strong>té</strong> (antériorité ou imparfait selon le verbe). La combinaison <strong>té ka</strong> correspond à l’imparfait duratif.</p>
+      <ul class="examples">
+        <li><strong>yo pati</strong> : ils sont partis</li>
+        <li><strong>man té di’w</strong> : je t’avais dit</li>
+        <li><strong>man té lé</strong> : je voulais / j’ai voulu</li>
+        <li><strong>i té ka travay</strong> : il travaillait</li>
+      </ul>
+    </section>
+
+    <section id="lesson-18">
+      <h2>Futur et conditionnel</h2>
+      <p>La particule <strong>ké</strong> marque le futur (avec variante proche <strong>kay</strong>). La combinaison <strong>té ké</strong> forme le conditionnel, tandis que <strong>sé</strong> peut rendre un conditionnel optatif. L’antériorité se gère avec <strong>fini</strong>.</p>
+      <ul class="examples">
+        <li><strong>nou ké dòmi bonnè</strong> : nous dormirons tôt</li>
+        <li><strong>ou kay travay</strong> : tu vas travailler (futur proche)</li>
+        <li><strong>yo té ké ja pati</strong> : ils seraient déjà partis</li>
+        <li><strong>man sé bwè an koko</strong> : je boirais bien un coco</li>
+      </ul>
+    </section>
+
+    <section id="lesson-19">
+      <h2>La phrase conditionnelle</h2>
+      <p>Les subordonnées conditionnelles utilisent <strong>si</strong> ou <strong>siyanka</strong> et se combinent avec différents temps (<strong>ka</strong>, forme simple, <strong>té ka</strong>, <strong>té ké</strong>, optatif). Le choix reflète la probabilité ou l’irréel.</p>
+      <ul class="examples">
+        <li><strong>si ou lévé, ou ké tann</strong> : si tu te lèves, tu entendras</li>
+        <li><strong>si ou té travay, ou té ké ni</strong> : si tu avais travaillé, tu aurais eu</li>
+        <li><strong>siyanka man touvé, man ké pòté</strong> : si je trouve, je porterai</li>
+        <li><strong>siyanka ou té ké ni, ou té ké ba</strong> : si tu avais, tu donnerais</li>
+      </ul>
+    </section>
+
+    <section id="lesson-20">
+      <h2>L’impératif</h2>
+      <p>L’impératif utilise la forme verbale simple, éventuellement doublée ou renforcée par des particules (<strong>anni</strong>, <strong>kon</strong>, <strong>tou sa</strong>). Certaines personnes emploient <strong>annou</strong> pour la 1<sup>re</sup> pluriel. Des expressions avec <strong>kité</strong>, <strong>ba</strong> ou <strong>prété</strong> rendent l’impératif aux autres personnes.</p>
+      <ul class="examples">
+        <li><strong>sòti la !</strong> : sors de là !</li>
+        <li><strong>pa menyen mwen !</strong> : ne me touche pas !</li>
+        <li><strong>annou chanté !</strong> : chantons !</li>
+        <li><strong>kit’an fè sa !</strong> : laisse-moi faire ça !</li>
+      </ul>
+      <p>Certains verbes comme <strong>lé</strong> ou <strong>pé</strong> n’ont pas d’impératif propre et recourent à des périphrases.</p>
+    </section>
+
+    <section id="lesson-21">
+      <h2>Le passif</h2>
+      <p>Le passif s’exprime sans changement morphologique majeur : on supprime l’agent ou on utilise des participes lexicalisés (<strong>pri</strong>, <strong>fèt</strong>, <strong>bay</strong>). Certaines constructions participiales complètent la description.</p>
+      <ul class="examples">
+        <li><strong>lèt-la voyé</strong> : la lettre est envoyée</li>
+        <li><strong>an kay byen fèt</strong> : une maison bien faite</li>
+        <li><strong>an lajan bay</strong> : une somme donnée</li> 
+        <li><strong>man ka wè’y ka monté mòn-la</strong> : je le vois montant la colline</li>
+      </ul>
+    </section>
+
+    <section id="lesson-22">
+      <h2>Les verbes composés</h2>
+      <p>Le créole combine fréquemment deux verbes pour préciser la nuance aspectuelle ou directionnelle. Un verbe porte le sens lexical, l’autre ajoute une orientation ou une manière.</p>
+      <ul class="examples">
+        <li><strong>maché alé</strong> : marcher vers l’extérieur · <strong>maché vini</strong> : marcher vers l’intérieur</li>
+        <li><strong>mennen alé</strong> : emmener · <strong>pòté vini</strong> : apporter</li>
+        <li><strong>tounen viré</strong> : virevolter · <strong>bay désann</strong> : descendre rapidement</li>
+        <li><strong>gadé wè</strong> : s’occuper de · <strong>chèché gadé wè</strong> : chercher à savoir insistance</li>
+      </ul>
+    </section>
+
+    <section id="lesson-23">
+      <h2>Obligation et probabilité</h2>
+      <p>Trois marqueurs principaux expriment l’obligation : <strong>fok/fo</strong>, <strong>pou</strong> et <strong>dwèt</strong>. Ce dernier véhicule aussi la notion de probabilité selon le contexte.</p>
+      <ul class="examples">
+        <li><strong>fòk ou travay</strong> : il faut que tu travailles</li>
+        <li><strong>sé pati pou nou pati</strong> : il nous faut partir</li>
+        <li><strong>Pyè dwèt travay</strong> : Pierre doit travailler / Pierre travaille sûrement</li>
+        <li><strong>ou té dwèt pati</strong> : tu aurais dû partir</li>
+      </ul>
+    </section>
+
+    <section id="lesson-24">
+      <h2>Le verbe « pouvoir »</h2>
+      <p><strong>pé</strong> traduit la capacité et la possibilité, souvent combiné à <strong>sa</strong> pour indiquer la réussite. La négation se fond avec <strong>pé</strong> au futur (<strong>pé ké</strong>). Le verbe peut aussi exprimer la probabilité.</p>
+      <ul class="examples">
+        <li><strong>ou pé pati</strong> : tu peux partir</li>
+        <li><strong>man ba’y san fran pou i pé sa manjé</strong> : je lui ai donné cent francs pour qu’il puisse manger</li>
+        <li><strong>man pé ké pé vini</strong> : je ne pourrai pas venir</li>
+        <li><strong>i pé ja rivé</strong> : il est peut-être déjà arrivé</li>
+      </ul>
+    </section>
+
+    <section id="lesson-25">
+      <h2>Les usages de « sé »</h2>
+      <p><strong>sé</strong> possède quatre fonctions : présentatif (« c’est »), marque du pluriel défini, copule équivalente à « être » et optatif (conditionnel). Plusieurs occurrences peuvent cohabiter dans une même phrase.</p>
+      <ul class="examples">
+        <li><strong>sa, sé ki bagay ?</strong> : ça, qu’est-ce que c’est ?</li>
+        <li><strong>sé zanmi’w la</strong> : tes amis</li>
+        <li><strong>ou sé an salop</strong> : tu es un salaud</li>
+        <li><strong>man sé bwè an koko</strong> : je boirais bien un coco</li>
+      </ul>
+    </section>
+
+    <section id="lesson-26">
+      <h2>Le nom commun</h2>
+      <p>Les noms peuvent apparaître sans article lorsqu’ils ont une valeur générique. Certains adjectifs ou verbes se nominalisent, souvent avec les préfixes <strong>la-</strong> ou <strong>le-</strong> pour les notions abstraites.</p>
+      <ul class="examples">
+        <li><strong>loto pa pou vini la</strong> : les voitures ne doivent pas venir ici</li>
+        <li><strong>lajistis sé an bon bagay</strong> : la justice est une bonne chose</li>
+        <li><strong>dòmi dous</strong> : c’est bon de dormir</li>
+        <li><strong>i fè an kay pa gran</strong> : il a construit une maison pas grande</li>
+      </ul>
+    </section>
+
+    <section id="lesson-27">
+      <h2>Noms propres, titres et adresses</h2>
+      <p>Les noms propres peuvent recevoir l’article pour marquer la distance. Les titres et formules d’adresse varient selon le registre : <strong>misyé</strong>, <strong>manzè</strong>, <strong>mésyédanm</strong>, <strong>monchè</strong>, etc. Les noms de pays utilisent des prépositions spécifiques.</p>
+      <ul class="examples">
+        <li><strong>Misiyé Pòl la</strong> : ce Monsieur Paul</li>
+        <li><strong>mésyédanm</strong> : Mesdames et messieurs</li>
+        <li><strong>man dirèktris la konprann...</strong> : cette directrice pense…</li>
+        <li><strong>yo ka soti an Frans</strong> : ils viennent de France</li>
+      </ul>
+    </section>
+
+    <section id="lesson-28">
+      <h2>L’adjectif</h2>
+      <p>De nombreux adjectifs résultent de relatives réduites ou de syntagmes nominalisés. Certains intensifs (<strong>bidim</strong>, <strong>manman</strong>) ou diminutifs (<strong>ti monyonyon</strong>) précèdent le nom. Le genre grammatical n’est pas marqué, mais des suffixes (<strong>-èz</strong>) peuvent souligner le féminin sémantique.</p>
+      <ul class="examples">
+        <li><strong>an boug vayan</strong> : un homme courageux</li>
+        <li><strong>an ti monyonyon pen</strong> : un tout petit bout de pain</li>
+        <li><strong>fanm ganmé a</strong> : la femme élégante</li>
+        <li><strong>Pyè, sé an boug blip</strong> : Pierre est un type mal dégrossi</li>
+      </ul>
+      <div class="note">Attention aux ambiguïtés : <strong>fanm kouyon an</strong> = la femme idiote ; <strong>fanm kouyon-an</strong> = la femme de l’idiot.</div>
+    </section>
+
+    <section id="lesson-29">
+      <h2>Le comparatif</h2>
+      <p>La supériorité se marque avec <strong>pli… ki/pasé</strong>, l’égalité avec <strong>osi… ki</strong> ou <strong>otan… otan</strong>, l’infériorité avec <strong>mwen(s)… ki</strong>. Des adverbes (<strong>titak</strong>, <strong>anpil</strong>, <strong>lontan</strong>) modulant l’intensité.</p>
+      <ul class="examples">
+        <li><strong>Pyè pli sòt ki Wobè</strong> : Pierre est plus bête que Robert</li>
+        <li><strong>Féfé osi gwo ki Pyè</strong> : Féfé est aussi gros que Pierre</li>
+        <li><strong>mwen gran ki Pyè</strong> : moins grand que Pierre</li>
+        <li><strong>pli ou ké dòmi, pli ou ké anvi dòmi</strong> : plus tu dormiras, plus tu auras envie de dormir</li>
+      </ul>
+    </section>
+
+    <section id="lesson-30">
+      <h2>Le superlatif</h2>
+      <p>Le superlatif relatif s’appuie sur <strong>pli</strong> ou <strong>mwen</strong> associés à l’article (<strong>sé… a</strong> pour le particulier, <strong>lé</strong> pour le général). Le superlatif absolu se forme par redoublement, particules intensives ou adjectifs comme <strong>bon</strong>, <strong>bèl</strong>, <strong>gwo</strong>, <strong>tou</strong>.</p>
+      <ul class="examples">
+        <li><strong>boug mwen pyétè a</strong> : le type le moins avare</li>
+        <li><strong>Pyè, sé boug pli séryé man konnèt</strong> : Pierre est le type le plus sérieux que je connaisse</li>
+        <li><strong>nou wè an bèl bèl fanm</strong> : nous avons vu une très belle femme</li>
+        <li><strong>i tou kagou</strong> : il est très malade</li>
+      </ul>
+    </section>
+
+    <section id="lesson-31">
+      <h2>Quantification et numération (I)</h2>
+      <p>Les adverbes/adjectifs de quantité incluent <strong>tout</strong>, <strong>chak</strong>, <strong>tjèk</strong>, <strong>yonndé</strong>, <strong>anpil</strong>, <strong>anlo</strong>, <strong>lòt</strong>, <strong>menm</strong>, <strong>kalté</strong>. Ils modulent la portée du nom selon qu’il est défini ou indéfini.</p>
+      <ul class="examples">
+        <li><strong>tout moun</strong> : tout le monde</li>
+        <li><strong>chak moun palé</strong> : chacun a parlé</li>
+        <li><strong>ni tjèk sé moun-la</strong> : il y a quelques-unes de ces personnes</li>
+        <li><strong>man pa enmen kalté moun-tala</strong> : je n’aime pas ce genre de personne</li>
+      </ul>
+    </section>
+
+    <section id="lesson-32">
+      <h2>Quantification et numération (II)</h2>
+      <p>Les numéraux cardinaux (yonn, dé, twa…) et ordinaux (prèmyé, dézyèm…) suivent des règles spécifiques. Certains servent d’intensif. Les expressions de durée ou de fréquence s’appuient sur ces formes.</p>
+      <ul class="examples">
+        <li><strong>ni dé lanné nou la</strong> : cela fait deux ans que nous sommes là</li>
+        <li><strong>ventan / ven lanné</strong> : vingt ans</li>
+        <li><strong>an dézyèm fi</strong> : une deuxième fille</li>
+        <li><strong>Pyè kouri sé dé prèmyé fwa-a</strong> : Pierre a couru les deux premières fois</li>
+      </ul>
+      <p>Des expressions comme <strong>lo</strong>, <strong>tèlman</strong>, <strong>an étsétéra</strong>, <strong>ti bren</strong> servent aussi à quantifier, parfois par antiphrase.</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>Mise à jour des règles grammaticales pour accompagner les exercices de créole martiniquais.</p>
+  </footer>
+
+  <script>
+    const lessonNav = document.querySelector('.lesson-nav');
+    const toggle = lessonNav?.querySelector('.menu-toggle');
+    const panel = lessonNav?.querySelector('.menu-panel');
+
+    if (lessonNav && toggle && panel) {
+      const closeMenu = () => {
+        toggle.setAttribute('aria-expanded', 'false');
+        panel.hidden = true;
+      };
+
+      toggle.addEventListener('click', () => {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!expanded));
+        panel.hidden = expanded;
+      });
+
+      panel.addEventListener('click', (event) => {
+        const link = event.target.closest('a');
+        if (link) {
+          closeMenu();
+        }
+      });
+
+      document.addEventListener('click', (event) => {
+        if (!lessonNav.contains(event.target)) {
+          closeMenu();
+        }
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+          closeMenu();
+          toggle.focus();
+        }
+      });
+    }
+  </script>
+</body>
+</html>

--- a/public/js/auth.js
+++ b/public/js/auth.js
@@ -1,0 +1,59 @@
+function setAlert(message, type = 'error') {
+  const alert = document.querySelector('[data-alert]');
+  if (!alert) return;
+  alert.textContent = message;
+  alert.classList.remove('success');
+  if (type === 'success') {
+    alert.classList.add('success');
+  }
+  alert.hidden = false;
+}
+
+async function submitForm(event, endpoint) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+
+  const payload = Object.fromEntries(formData.entries());
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ message: 'Une erreur est survenue.' }));
+      setAlert(error.message || 'Une erreur est survenue.');
+      return;
+    }
+
+    const data = await response.json();
+    setAlert('Connexion réussie! Redirection...', 'success');
+    setTimeout(() => {
+      window.location.href = payload.redirectTo || '/modules/introduction';
+    }, 600);
+    return data;
+  } catch (error) {
+    console.error('Form submission failed', error); // eslint-disable-line no-console
+    setAlert("Impossible d'envoyer le formulaire.");
+    return null;
+  }
+}
+
+function initializeAuthForms() {
+  const loginForm = document.querySelector('[data-login-form]');
+  const signupForm = document.querySelector('[data-signup-form]');
+
+  if (loginForm) {
+    loginForm.addEventListener('submit', (event) => submitForm(event, '/api/auth/login'));
+  }
+
+  if (signupForm) {
+    signupForm.addEventListener('submit', (event) => submitForm(event, '/api/auth/signup'));
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initializeAuthForms);

--- a/public/js/guard.js
+++ b/public/js/guard.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const guardTarget = document.querySelector('[data-requires-subscription]');
+  try {
+    const user = await window.Session.ensureActiveSubscription();
+    if (user && guardTarget) {
+      guardTarget.dataset.userEmail = user.email;
+    }
+  } catch (error) {
+    console.error('Unable to enforce session guard', error); // eslint-disable-line no-console
+  }
+});

--- a/public/js/session.js
+++ b/public/js/session.js
@@ -1,0 +1,39 @@
+async function fetchSession() {
+  const response = await fetch('/api/auth/me', {
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = await response.json();
+  return data.user;
+}
+
+async function ensureAuthenticated() {
+  const user = await fetchSession();
+  if (!user) {
+    window.location.href = '/login.html';
+    return null;
+  }
+  return user;
+}
+
+async function ensureActiveSubscription() {
+  const user = await ensureAuthenticated();
+  if (!user) {
+    return null;
+  }
+  if (user.subscription_status !== 'active') {
+    window.location.href = '/subscribe.html';
+    return null;
+  }
+  return user;
+}
+
+window.Session = {
+  fetchSession,
+  ensureAuthenticated,
+  ensureActiveSubscription,
+};

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Connexion - Kreyolang</title>
+  <link rel="stylesheet" href="/css/app.css" />
+  <script src="/js/auth.js" defer></script>
+</head>
+<body>
+  <form class="auth-form" data-login-form>
+    <h1>Connexion</h1>
+    <p class="alert" data-alert hidden></p>
+    <label>
+      Adresse e-mail
+      <input type="email" name="email" autocomplete="email" required />
+    </label>
+    <label>
+      Mot de passe
+      <input type="password" name="password" autocomplete="current-password" required />
+    </label>
+    <button type="submit">Se connecter</button>
+    <p class="form-footer">
+      Pas encore de compte?
+      <a href="/signup.html">Créer un compte</a>
+    </p>
+  </form>
+</body>
+</html>

--- a/public/signup.html
+++ b/public/signup.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Inscription - Kreyolang</title>
+  <link rel="stylesheet" href="/css/app.css" />
+  <script src="/js/auth.js" defer></script>
+</head>
+<body>
+  <form class="auth-form" data-signup-form>
+    <h1>Créer un compte</h1>
+    <p class="alert" data-alert hidden></p>
+    <label>
+      Nom complet (optionnel)
+      <input type="text" name="name" autocomplete="name" />
+    </label>
+    <label>
+      Adresse e-mail
+      <input type="email" name="email" autocomplete="email" required />
+    </label>
+    <label>
+      Mot de passe
+      <input type="password" name="password" autocomplete="new-password" required minlength="8" />
+    </label>
+    <button type="submit">Créer mon compte</button>
+    <p class="form-footer">
+      Déjà membre?
+      <a href="/login.html">Se connecter</a>
+    </p>
+  </form>
+</body>
+</html>

--- a/public/subscribe.html
+++ b/public/subscribe.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>S'abonner - Kreyolang</title>
+  <link rel="stylesheet" href="/css/app.css" />
+  <script src="/js/session.js" defer></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', async () => {
+      const user = await window.Session.ensureAuthenticated();
+      const message = document.querySelector('[data-subscription-state]');
+      if (!user || !message) return;
+      if (user.subscription_status === 'active') {
+        message.textContent = 'Votre abonnement est déjà actif. Rendez-vous sur vos modules !';
+      }
+    });
+  </script>
+</head>
+<body>
+  <main>
+    <h1>Activer mon abonnement</h1>
+    <p data-subscription-state>
+      Pour accéder aux modules, finalisez votre abonnement via notre portail de paiement sécurisé.
+    </p>
+    <p>
+      Une fois le paiement validé, Stripe nous enverra un webhook pour activer votre compte automatiquement.
+    </p>
+    <p>
+      Besoin d'aide? Contactez-nous à <a href="mailto:support@kreyolang.com">support@kreyolang.com</a>.
+    </p>
+  </main>
+</body>
+</html>

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const CONFIG = require('./config');
+const authRoutes = require('./routes/auth');
+const { apiRouter: moduleApiRouter, pageRouter: modulePageRouter } = require('./routes/modules');
+const webhookRoutes = require('./routes/webhook');
+const { attachUser } = require('./middleware/auth');
+
+const app = express();
+
+if (!fs.existsSync(path.join(process.cwd(), 'data'))) {
+  fs.mkdirSync(path.join(process.cwd(), 'data'));
+}
+
+app.use(cookieParser());
+app.use('/webhooks/stripe', webhookRoutes);
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(attachUser);
+
+app.use('/api/auth', authRoutes);
+app.use('/api/modules', moduleApiRouter);
+app.use('/modules', modulePageRouter);
+
+app.use(express.static(path.join(__dirname, '..', 'public'), { extensions: ['html'] }));
+
+app.use((err, _req, res, _next) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  res.status(500).json({ message: 'Internal server error.' });
+});
+
+if (require.main === module) {
+  app.listen(CONFIG.port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`Server listening on http://localhost:${CONFIG.port}`);
+  });
+}
+
+module.exports = app;

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,26 @@
+const path = require('path');
+const dotenv = require('dotenv');
+
+dotenv.config({ path: path.resolve(process.cwd(), '.env') });
+
+tableMissing(['JWT_SECRET']);
+
+function tableMissing(required) {
+  required.forEach((key) => {
+    if (!process.env[key]) {
+      // eslint-disable-next-line no-console
+      console.warn(`Warning: environment variable ${key} is not set.`);
+    }
+  });
+}
+
+const CONFIG = {
+  jwtSecret: process.env.JWT_SECRET || 'development-secret',
+  cookieName: process.env.AUTH_COOKIE_NAME || 'kreyolang_session',
+  isProduction: process.env.NODE_ENV === 'production',
+  stripeSecretKey: process.env.STRIPE_SECRET_KEY || '',
+  stripeWebhookSecret: process.env.STRIPE_WEBHOOK_SECRET || '',
+  port: process.env.PORT || 3000,
+};
+
+module.exports = CONFIG;

--- a/server/db/index.js
+++ b/server/db/index.js
@@ -1,0 +1,82 @@
+const path = require('path');
+const Database = require('better-sqlite3');
+
+const dbPath = path.join(process.cwd(), 'data', 'app.sqlite');
+
+const db = new Database(dbPath);
+
+db.pragma('foreign_keys = ON');
+db.pragma('journal_mode = WAL');
+
+db.exec(`
+  CREATE TABLE IF NOT EXISTS users (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    email TEXT NOT NULL UNIQUE,
+    name TEXT,
+    password_hash TEXT NOT NULL,
+    stripe_customer_id TEXT,
+    subscription_status TEXT DEFAULT 'inactive',
+    subscription_expires_at TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+  );
+`);
+
+const updateTimestampTrigger = `
+  CREATE TRIGGER IF NOT EXISTS users_updated_at
+  AFTER UPDATE ON users
+  BEGIN
+    UPDATE users SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+  END;
+`;
+
+db.exec(updateTimestampTrigger);
+
+const statements = {
+  createUser: db.prepare(`
+    INSERT INTO users (email, name, password_hash, stripe_customer_id, subscription_status)
+    VALUES (@email, @name, @password_hash, @stripe_customer_id, @subscription_status)
+  `),
+  findUserByEmail: db.prepare('SELECT * FROM users WHERE email = ?'),
+  findUserById: db.prepare('SELECT * FROM users WHERE id = ?'),
+  updateStripeCustomerId: db.prepare('UPDATE users SET stripe_customer_id = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?'),
+  updateSubscriptionStatus: db.prepare('UPDATE users SET subscription_status = ?, subscription_expires_at = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?'),
+};
+
+function createUser({ email, name, passwordHash, stripeCustomerId, subscriptionStatus = 'inactive' }) {
+  const info = statements.createUser.run({
+    email,
+    name,
+    password_hash: passwordHash,
+    stripe_customer_id: stripeCustomerId || null,
+    subscription_status: subscriptionStatus,
+  });
+  return statements.findUserById.get(info.lastInsertRowid);
+}
+
+function findUserByEmail(email) {
+  return statements.findUserByEmail.get(email);
+}
+
+function findUserById(id) {
+  return statements.findUserById.get(id);
+}
+
+function setStripeCustomerId(userId, customerId) {
+  statements.updateStripeCustomerId.run(customerId, userId);
+  return findUserById(userId);
+}
+
+function setSubscriptionStatus(userId, status, expiresAt = null) {
+  statements.updateSubscriptionStatus.run(status, expiresAt, userId);
+  return findUserById(userId);
+}
+
+module.exports = {
+  createUser,
+  findUserByEmail,
+  findUserById,
+  setStripeCustomerId,
+  setSubscriptionStatus,
+  db,
+};

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -1,0 +1,91 @@
+const jwt = require('jsonwebtoken');
+const CONFIG = require('../config');
+const { findUserById } = require('../db');
+
+function getTokenFromRequest(req) {
+  return req.cookies?.[CONFIG.cookieName];
+}
+
+function signToken(user) {
+  return jwt.sign({ userId: user.id }, CONFIG.jwtSecret, {
+    expiresIn: '7d',
+  });
+}
+
+function issueAuthCookie(res, user) {
+  const token = signToken(user);
+  res.cookie(CONFIG.cookieName, token, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: CONFIG.isProduction,
+    maxAge: 7 * 24 * 60 * 60 * 1000,
+  });
+}
+
+function clearAuthCookie(res) {
+  res.clearCookie(CONFIG.cookieName, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: CONFIG.isProduction,
+  });
+}
+
+function attachUser(req, _res, next) {
+  const token = getTokenFromRequest(req);
+  if (!token) {
+    return next();
+  }
+
+  try {
+    const decoded = jwt.verify(token, CONFIG.jwtSecret);
+    const user = findUserById(decoded.userId);
+    if (user) {
+      req.user = user;
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Invalid auth token provided', error.message);
+  }
+
+  return next();
+}
+
+function requireAuth(req, res, next) {
+  if (!req.user) {
+    const wantsHtml = req.accepts(['html', 'json']) === 'html';
+    if (wantsHtml) {
+      return res.redirect('/login.html');
+    }
+    return res.status(401).json({ message: 'Authentication required.' });
+  }
+  return next();
+}
+
+function requireActiveSubscription(req, res, next) {
+  if (!req.user) {
+    const wantsHtml = req.accepts(['html', 'json']) === 'html';
+    if (wantsHtml) {
+      return res.redirect('/login.html');
+    }
+    return res.status(401).json({ message: 'Authentication required.' });
+  }
+  if (req.user.subscription_status !== 'active') {
+    const wantsHtml = req.accepts(['html', 'json']) === 'html';
+    if (wantsHtml) {
+      return res.redirect('/subscribe.html');
+    }
+    return res.status(402).json({
+      message: 'Active subscription required.',
+      code: 'subscription_required',
+    });
+  }
+  return next();
+}
+
+module.exports = {
+  attachUser,
+  requireAuth,
+  requireActiveSubscription,
+  issueAuthCookie,
+  clearAuthCookie,
+};

--- a/server/protected/modules/introduction.html
+++ b/server/protected/modules/introduction.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Module d'introduction - Kreyolang</title>
+  <link rel="stylesheet" href="/css/app.css" />
+  <script src="/js/session.js" defer></script>
+  <script src="/js/guard.js" defer></script>
+</head>
+<body data-requires-subscription>
+  <main class="module">
+    <header>
+      <h1>Introduction à Kreyolang</h1>
+      <p class="module__tag">Contenu réservé aux abonnés</p>
+    </header>
+    <article>
+      <p>
+        Byenveni! Ce module de démonstration montre comment le contenu premium est protégé par une
+        vérification d'abonnement côté serveur et un garde côté client.
+      </p>
+      <p>
+        Utilisez cette structure pour servir vos propres leçons. Vous pouvez éditer ce fichier dans
+        <code>server/protected/modules/introduction.html</code> ou en ajouter de nouveaux dans le même dossier.
+      </p>
+      <p>
+        Bon apprentissage!
+      </p>
+    </article>
+  </main>
+</body>
+</html>

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,127 @@
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const Stripe = require('stripe');
+const CONFIG = require('../config');
+const {
+  createUser,
+  findUserByEmail,
+  setStripeCustomerId,
+} = require('../db');
+const {
+  issueAuthCookie,
+  clearAuthCookie,
+  requireAuth,
+} = require('../middleware/auth');
+
+const router = express.Router();
+
+let stripe = null;
+if (CONFIG.stripeSecretKey) {
+  stripe = new Stripe(CONFIG.stripeSecretKey, {
+    apiVersion: '2023-10-16',
+  });
+}
+
+function serializeUser(user) {
+  if (!user) return null;
+  const {
+    password_hash: _passwordHash,
+    ...safeUser
+  } = user;
+  return safeUser;
+}
+
+router.post('/signup', async (req, res) => {
+  const { email, password, name } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password are required.' });
+  }
+
+  const existing = findUserByEmail(email);
+  if (existing) {
+    return res.status(409).json({ message: 'An account with this email already exists.' });
+  }
+
+  const passwordHash = await bcrypt.hash(password, 12);
+
+  let stripeCustomerId = null;
+  if (stripe) {
+    try {
+      const customer = await stripe.customers.create({
+        email,
+        name,
+        metadata: { application: 'Kreyolang' },
+      });
+      stripeCustomerId = customer.id;
+    } catch (error) {
+      return res.status(502).json({ message: 'Unable to create Stripe customer.', details: error.message });
+    }
+  }
+
+  const user = createUser({
+    email,
+    name: name || null,
+    passwordHash,
+    stripeCustomerId,
+  });
+
+  issueAuthCookie(res, user);
+
+  return res.status(201).json({ user: serializeUser(user) });
+});
+
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+
+  if (!email || !password) {
+    return res.status(400).json({ message: 'Email and password are required.' });
+  }
+
+  const user = findUserByEmail(email);
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid email or password.' });
+  }
+
+  const validPassword = await bcrypt.compare(password, user.password_hash);
+  if (!validPassword) {
+    return res.status(401).json({ message: 'Invalid email or password.' });
+  }
+
+  issueAuthCookie(res, user);
+
+  return res.json({ user: serializeUser(user) });
+});
+
+router.post('/logout', (_req, res) => {
+  clearAuthCookie(res);
+  return res.status(204).end();
+});
+
+router.get('/me', requireAuth, (req, res) => {
+  return res.json({ user: serializeUser(req.user) });
+});
+
+router.post('/stripe/customer', requireAuth, async (req, res) => {
+  if (!stripe) {
+    return res.status(503).json({ message: 'Stripe integration is not configured.' });
+  }
+
+  if (req.user.stripe_customer_id) {
+    return res.json({ user: serializeUser(req.user) });
+  }
+
+  try {
+    const customer = await stripe.customers.create({
+      email: req.user.email,
+      name: req.user.name,
+      metadata: { application: 'Kreyolang' },
+    });
+    const updated = setStripeCustomerId(req.user.id, customer.id);
+    return res.json({ user: serializeUser(updated) });
+  } catch (error) {
+    return res.status(502).json({ message: 'Unable to create Stripe customer.', details: error.message });
+  }
+});
+
+module.exports = router;

--- a/server/routes/modules.js
+++ b/server/routes/modules.js
@@ -1,0 +1,50 @@
+const path = require('path');
+const fs = require('fs');
+const express = require('express');
+const { requireActiveSubscription } = require('../middleware/auth');
+
+const modulesDirectory = path.join(__dirname, '..', 'protected', 'modules');
+
+if (!fs.existsSync(modulesDirectory)) {
+  fs.mkdirSync(modulesDirectory, { recursive: true });
+}
+
+const apiRouter = express.Router();
+const pageRouter = express.Router();
+
+apiRouter.get('/', requireActiveSubscription, (_req, res) => {
+  const files = fs.readdirSync(modulesDirectory)
+    .filter((file) => file.endsWith('.html'))
+    .map((file) => ({
+      slug: path.basename(file, '.html'),
+      title: path.basename(file, '.html').replace(/[-_]/g, ' '),
+      href: `/modules/${path.basename(file, '.html')}`,
+    }));
+
+  res.json({ modules: files });
+});
+
+pageRouter.get('/', requireActiveSubscription, (_req, res) => {
+  const files = fs.readdirSync(modulesDirectory)
+    .filter((file) => file.endsWith('.html'))
+    .map((file) => path.basename(file, '.html'));
+
+  if (files.length === 0) {
+    return res.status(204).end();
+  }
+
+  return res.redirect(`/modules/${files[0]}`);
+});
+
+pageRouter.get('/:slug', requireActiveSubscription, (req, res, next) => {
+  const filePath = path.join(modulesDirectory, `${req.params.slug}.html`);
+  if (!fs.existsSync(filePath)) {
+    return next();
+  }
+  return res.sendFile(filePath);
+});
+
+module.exports = {
+  apiRouter,
+  pageRouter,
+};

--- a/server/routes/webhook.js
+++ b/server/routes/webhook.js
@@ -1,0 +1,61 @@
+const express = require('express');
+const Stripe = require('stripe');
+const CONFIG = require('../config');
+const { setSubscriptionStatus, db } = require('../db');
+
+const router = express.Router();
+
+let stripe = null;
+if (CONFIG.stripeSecretKey) {
+  stripe = new Stripe(CONFIG.stripeSecretKey, {
+    apiVersion: '2023-10-16',
+  });
+}
+
+router.post('/', express.raw({ type: 'application/json' }), (req, res) => {
+  if (!stripe || !CONFIG.stripeWebhookSecret) {
+    return res.status(503).json({ message: 'Stripe integration is not configured.' });
+  }
+
+  const signature = req.headers['stripe-signature'];
+
+  let event;
+  try {
+    event = stripe.webhooks.constructEvent(req.body, signature, CONFIG.stripeWebhookSecret);
+  } catch (error) {
+    return res.status(400).send(`Webhook Error: ${error.message}`);
+  }
+
+  const data = event.data.object;
+
+  if (event.type === 'customer.subscription.created' || event.type === 'customer.subscription.updated') {
+    const customerId = data.customer;
+    const status = data.status === 'active' || data.status === 'trialing' ? 'active' : 'inactive';
+    const expiresAt = data.current_period_end ? new Date(data.current_period_end * 1000).toISOString() : null;
+    if (customerId) {
+      const user = findUserByStripeCustomerId(customerId);
+      if (user) {
+        setSubscriptionStatus(user.id, status, expiresAt);
+      }
+    }
+  }
+
+  if (event.type === 'customer.subscription.deleted') {
+    const customerId = data.customer;
+    if (customerId) {
+      const user = findUserByStripeCustomerId(customerId);
+      if (user) {
+        setSubscriptionStatus(user.id, 'inactive', null);
+      }
+    }
+  }
+
+  res.json({ received: true });
+});
+
+function findUserByStripeCustomerId(stripeCustomerId) {
+  const stmt = db.prepare('SELECT * FROM users WHERE stripe_customer_id = ?');
+  return stmt.get(stripeCustomerId);
+}
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add an Express backend with SQLite persistence for users, hashed credentials, and JWT-powered sessions stored in secure cookies
- integrate Stripe customer provisioning plus webhook handling to keep subscription status in sync
- protect module pages server-side and add login, signup, and subscription management pages with front-end guards

## Testing
- ⚠️ `npm install` *(fails: registry access to bcryptjs is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbee0d7a4c832e93d8dfdcea1b7268