### PR TITLE
Improve lesson menu toggle accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -776,9 +776,23 @@
       };
 
       toggle.addEventListener('click', () => {
-        const expanded = toggle.getAttribute('aria-expanded') === 'true';
-        toggle.setAttribute('aria-expanded', String(!expanded));
-        panel.hidden = expanded;
+        const nextExpanded = toggle.getAttribute('aria-expanded') !== 'true';
+
+        if (!nextExpanded) {
+          closeMenu();
+          return;
+        }
+
+        toggle.setAttribute('aria-expanded', 'true');
+        panel.hidden = false;
+
+        if (!panel.hasAttribute('tabindex')) {
+          panel.setAttribute('tabindex', '-1');
+        }
+
+        if (document.activeElement !== panel) {
+          panel.focus({ preventScroll: true });
+        }
       });
 
       panel.addEventListener('click', (event) => {


### PR DESCRIPTION
## Summary
- ensure the lesson menu toggle closes the panel consistently when collapsing
- focus the lesson menu panel when opened so keyboard users can navigate it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbee0bb840832e832b28f049bb3345